### PR TITLE
Update content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta charset="utf-8" />
 	<title>SNMP Library for Ruby</title>
-	<style type="text/css">
+	<style>
 	body {
 		margin:0;
 		padding:0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
 	</style>
 </head>
 <body>
-<a href="http://github.com/ruby-snmp/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a> 
+<a href="https://github.com/ruby-snmp/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a> 
 <div id="wrap">
   <img src="rubysnmp.gif" alt="Ruby SNMP" width="290" height="50"/>
 	<div id="main">
@@ -92,11 +92,11 @@
 	  <h2>Getting Started</h2>
 
 	  <h3>Install</h3>
-	  <p>Using <a href="http://rubygems.org/">RubyGems</a> all you need to do is:</p>
+	  <p>Using <a href="https://rubygems.org/">RubyGems</a> all you need to do is:</p>
 	  <p><code>gem install snmp</code></p>
 
     <h3>Import MIBs</h3>
-    <p>If you are using standard <a href="http://www.ietf.org/">IETF</a> MIBs then you're ready to go.  Most of the IETF MIBs have been included for you with Ruby SNMP.  Just list the MIBs that you need when you open your SNMP session and you will have full symbolic access to all of the OIDs.</p>
+    <p>If you are using standard <a href="https://www.ietf.org/">IETF</a> MIBs then you're ready to go.  Most of the IETF MIBs have been included for you with Ruby SNMP.  Just list the MIBs that you need when you open your SNMP session and you will have full symbolic access to all of the OIDs.</p>
     
     <pre><code>
 SNMP::Manager.open(:MibModules =&gt; ["DOCS-IF-MIB"]) do |snmp|
@@ -106,7 +106,7 @@ end</code></pre>
     
     <p>If you don't provide a MIB list then the default MIBs are loaded: SNMPv2-MIB, IF-MIB, IP-MIB, TCP-MIB, UDP-MIB</p>
     
-    <p>If you want to import custom MIBs, then have a look at the <a href="doc/index.html">documentation</a> for the <code>SNMP::MIB</code> class.  If you use the <code>import_module</code> method, you will need to install <a href="http://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> first, or create the required YAML file manually.</p>
+    <p>If you want to import custom MIBs, then have a look at the <a href="doc/index.html">documentation</a> for the <code>SNMP::MIB</code> class.  If you use the <code>import_module</code> method, you will need to install <a href="https://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> first, or create the required YAML file manually.</p>
     
     <h3>Start Coding</h3>
     
@@ -128,16 +128,16 @@ end</code></pre>
 
 	  <h3>libsmi</h3>
 
-	  <p>The <a href="http://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> distribution includes some very useful tools for checking, analyzing, converting, and comparing MIBs.  It also contains a complete archive of IETF and IANA MIBs which saves you from having to find and download them yourself.</p>
+	  <p>The <a href="https://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> distribution includes some very useful tools for checking, analyzing, converting, and comparing MIBs.  It also contains a complete archive of IETF and IANA MIBs which saves you from having to find and download them yourself.</p>
 
 	  <h3>Net-SNMP</h3>
 
-	  <p><a href="http://net-snmp.sourceforge.net/">Net-SNMP</a> includes SNMP libraries for implementing SNMP agents and managers in C and a set of SNMP tools for setting and getting information from SNMP agents.</p>
+	  <p><a href="https://net-snmp.sourceforge.io/">Net-SNMP</a> includes SNMP libraries for implementing SNMP agents and managers in C and a set of SNMP tools for setting and getting information from SNMP agents.</p>
 	  
 	</div>
 	<div id="sidebar">
 	  <h3><a href="doc/index.html">Documentation &raquo;</a></h3>
-    <h3><a href="http://rubygems.org/gems/snmp/">Download &raquo;</a></h3>
+    <h3><a href="https://rubygems.org/gems/snmp/">Download &raquo;</a></h3>
     <h3>Happy Users</h3>
     <div id="quotes">
     <p>&ldquo;I'd like to thank you for such a fantastic library.&rdquo;</p>
@@ -151,7 +151,7 @@ end</code></pre>
 
 		<h3>What is Ruby?</h3>
 		<p>Ruby is the interpreted scripting language for quick and easy object-oriented programming. It has many features to process text files and to do system management tasks (as in Perl). It is simple, straight-forward, extensible, and portable.</p>
-		<p>Find out more at <a href="http://www.ruby-lang.org/en/">www.ruby-lang.org</a>.</p>
+		<p>Find out more at <a href="https://www.ruby-lang.org/en/">www.ruby-lang.org</a>.</p>
 		<p>&nbsp;</p>
      
 	</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,13 +106,13 @@ end</code></pre>
     
     <p>If you don't provide a MIB list then the default MIBs are loaded: SNMPv2-MIB, IF-MIB, IP-MIB, TCP-MIB, UDP-MIB</p>
     
-    <p>If you want to import custom MIBs, then have a look at the <a href="doc/index.html">documentation</a> for the <code>SNMP::MIB</code> class.  If you use the <code>import_module</code> method, you will need to install <a href="https://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> first, or create the required YAML file manually.</p>
+    <p>If you want to import custom MIBs, then have a look at the <a href="https://www.rubydoc.info/gems/snmp/">documentation</a> for the <code>SNMP::MIB</code> class.  If you use the <code>import_module</code> method, you will need to install <a href="https://www.ibr.cs.tu-bs.de/projects/libsmi/">libsmi</a> first, or create the required YAML file manually.</p>
     
     <h3>Start Coding</h3>
     
-    <p>Have a look at the <a href="doc/index.html">documentation</a> for the <code>SNMP::Manager</code> class.  This class provides the main interface for sending and receiving SNMP PDUs.</p>
+    <p>Have a look at the <a href="https://www.rubydoc.info/gems/snmp/">documentation</a> for the <code>SNMP::Manager</code> class.  This class provides the main interface for sending and receiving SNMP PDUs.</p>
 
-<p>Here's an example to get you started.  You can find plenty more in the <a href="doc/index.html">README</a> file</p>    
+<p>Here's an example to get you started.  You can find plenty more in the <a href="https://www.rubydoc.info/gems/snmp/">README</a> file</p>
 <pre><code>
 require 'snmp'
 
@@ -136,7 +136,7 @@ end</code></pre>
 	  
 	</div>
 	<div id="sidebar">
-	  <h3><a href="doc/index.html">Documentation &raquo;</a></h3>
+	  <h3><a href="https://www.rubydoc.info/gems/snmp/">Documentation &raquo;</a></h3>
     <h3><a href="https://rubygems.org/gems/snmp/">Download &raquo;</a></h3>
     <h3>Happy Users</h3>
     <div id="quotes">

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
 	</style>
 </head>
 <body>
-<a href="https://github.com/ruby-snmp/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" /></a> 
+<a href="https://github.com/ruby-snmp/ruby-snmp/"><img style="position: absolute; top: 0; right: 0; border: 0;" loading="lazy" decoding="async" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" class="attachment-full size-full" alt="Fork me on GitHub"></a>
 <div id="wrap">
   <img src="rubysnmp.gif" alt="Ruby SNMP" width="290" height="50"/>
 	<div id="main">


### PR DESCRIPTION
### Summary
Fix broken links and miscellaneous updates

### Changes
- Replace documentation URL from RDoc-generated content to RubyDoc.info (https://www.rubydoc.info/gems/snmp/)